### PR TITLE
feat: add zoom controls to tile map

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -6,4 +6,7 @@ export const parameters = {
       date: /Date$/,
     },
   },
+  options: {
+    storySort: (a, b) => Number.parseInt(a[1].name) - Number.parseInt(b[1].name)
+  }
 }

--- a/src/components/TileMap/TileMap.css
+++ b/src/components/TileMap/TileMap.css
@@ -45,3 +45,52 @@
 .react-tile-map-popup.visible {
   opacity: 1;
 }
+
+.react-tile-map .zoom-controls {
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  right: 20px;
+  bottom: 20px;
+  box-shadow: 0 1px 8px rgb(0 0 0 / 30%);
+  border-radius: 6px;
+}
+
+.react-tile-map .zoom-controls button {
+  color: rgb(214, 214, 214);
+  font-size: 20px;
+  background-color: #736e7d;
+  border: 0;
+  height: 48px;
+  width: 40px;
+  position: relative;
+  cursor: pointer;
+}
+
+.react-tile-map .zoom-controls button:hover:not(:disabled) {
+  color: white;
+}
+
+.react-tile-map .zoom-controls button:disabled {
+  cursor: default;
+  color: #969696
+}
+
+.react-tile-map .zoom-controls button:first-child {
+  border-radius: 6px 6px 0 0;
+}
+
+.react-tile-map .zoom-controls button:last-child {
+  border-radius: 0 0 6px 6px;
+}
+
+.react-tile-map .zoom-controls button:last-child::before {
+  content: '';
+  position: absolute;
+  left: 10%;
+  top: -2px;
+  height: 1px;
+  width: 80%;
+  border-bottom: 1px solid #161419;
+  opacity: 0.4;
+}

--- a/src/components/TileMap/TileMap.types.ts
+++ b/src/components/TileMap/TileMap.types.ts
@@ -39,6 +39,8 @@ export type Props = {
   isDraggable: boolean
   /** amount of padding tiles */
   padding: number
+  /** whether the zoom controls should appear */
+  withZoomControls: boolean
   /** callbacks */
   onMouseDown?: (x: number, y: number) => void
   onMouseUp?: (x: number, y: number) => void

--- a/stories/10_Atlas_zoom_controls.stories.tsx
+++ b/stories/10_Atlas_zoom_controls.stories.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react'
+
+import { storiesOf } from '@storybook/react'
+// @ts-ignore
+import { withKnobs, number } from '@storybook/addon-knobs'
+
+import { TileMap, Layer } from '../src'
+
+type AtlasTile = {
+  x: number
+  y: number
+  type: number
+  estate_id: number
+  left: number
+  top: number
+  topLeft: number
+}
+
+let atlas: Record<string, AtlasTile> | null = null
+
+async function loadTiles() {
+  const resp = await fetch('https://api.decentraland.org/v1/tiles')
+  const json = await resp.json()
+  atlas = json.data as Record<string, AtlasTile>
+}
+
+loadTiles().catch(console.error)
+
+const stories = storiesOf('TileMap', module)
+
+stories.addDecorator(withKnobs)
+
+export const COLOR_BY_TYPE = Object.freeze({
+  0: '#ff9990', // my parcels
+  1: '#ff4053', // my parcels on sale
+  2: '#ff9990', // my estates
+  3: '#ff4053', // my estates on sale
+  4: '#ffbd33', // parcels/estates where I have permissions
+  5: '#5054D4', // districts
+  6: '#563db8', // contributions
+  7: '#716C7A', // roads
+  8: '#70AC76', // plazas
+  9: '#3D3A46', // owned parcel/estate
+  10: '#3D3A46', // parcels on sale (we show them as owned parcels)
+  11: '#09080A', // unowned pacel/estate
+  12: '#18141a', // background
+  13: '#110e13', // loading odd
+  14: '#0d0b0e' // loading even
+})
+
+const atlasLayer: Layer = (x, y) => {
+  const id = x + ',' + y
+  if (atlas !== null && id in atlas) {
+    const tile = atlas[id]
+    const color = COLOR_BY_TYPE[tile.type]
+
+    const top = !!tile.top
+    const left = !!tile.left
+    const topLeft = !!tile.topLeft
+
+    return {
+      color,
+      top,
+      left,
+      topLeft
+    }
+  } else {
+    return {
+      color: (x + y) % 2 === 0 ? COLOR_BY_TYPE[12] : COLOR_BY_TYPE[13]
+    }
+  }
+}
+
+stories.add('10. With zoom controls', () => {
+  return (
+    <TileMap
+      className="atlas"
+      layers={[atlasLayer]}
+      x={number('x', 0)}
+      y={number('y', 0)}
+      withZoomControls
+    />
+  )
+})

--- a/stories/10_Atlas_zoom_controls.stories.tsx
+++ b/stories/10_Atlas_zoom_controls.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react'
-
 import { storiesOf } from '@storybook/react'
-// @ts-ignore
-import { withKnobs, number } from '@storybook/addon-knobs'
+import { number } from '@storybook/addon-knobs'
 
 import { TileMap, Layer } from '../src'
 
@@ -27,8 +25,6 @@ async function loadTiles() {
 loadTiles().catch(console.error)
 
 const stories = storiesOf('TileMap', module)
-
-stories.addDecorator(withKnobs)
 
 export const COLOR_BY_TYPE = Object.freeze({
   0: '#ff9990', // my parcels


### PR DESCRIPTION
Add zoom controls to tile map. To show zoom controls the propery `withZoomControls` should be true
<img width="867" alt="image" src="https://user-images.githubusercontent.com/11800206/225190087-638ae93a-a7d4-47a4-b3c3-3ff24539a851.png">


Add sorting function to storybook as adding a new story `10` messed up with the order 
