### PR TITLE
fix: Package typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.d.ts
 *.css
-lib
+dist
 node_modules
-lib
+
+.vscode
+.DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "typescript.tsdk": "node_modules/typescript/lib"
-}

--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
   "name": "react-tile-map",
   "version": "0.3.3",
   "description": "",
-  "main": "lib/index.js",
-  "typings": "lib/src/index.d.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "start": "start-storybook -p 6006",
-    "build": "rimraf lib && webpack --config webpack.config.js && rimraf lib/stories",
+    "build": "rimraf dist && webpack --config webpack.config.js",
     "build-storybook": "build-storybook",
     "prepublish": "npm run build",
     "deploy": "npm run build-storybook && now alias $(now storybook-static --public) tile-map --scope=decentraland"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "paths": { "*": ["types/*"] },
-    "outDir": "lib",
+    "outDir": "dist",
     "module": "commonjs",
     "target": "es5",
     "lib": ["es7", "dom"],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,11 @@
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
-const postcssPresetEnv = require('postcss-preset-env')
 const path = require('path')
 
 module.exports = {
   mode: 'production',
   entry: './src/index.ts',
   output: {
-    path: path.resolve(__dirname, 'lib'),
+    path: path.resolve(__dirname, 'dist'),
     filename: 'index.js',
     library: 'TileMap',
     libraryTarget: 'umd',


### PR DESCRIPTION
This PR does the following:
- Fixes the typings by changing the `typings` property to point to the correct types path.
- Changes the lib directory into `dist` as other packages do.
- Adds the `files` property to the `package.json` so it includes only the dist files.